### PR TITLE
fix: enable HTTP redirects and improve API key retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ Showcase of HTB Toolkit:
 [![HTB Toolkit Asciicast](https://github.com/D3vil0p3r/htb-toolkit/assets/83867734/cfc8aac4-f58e-4b44-8ac1-12e1842c801f)](https://asciinema.org/a/605148)
 Interactive source: [Asciinema](https://asciinema.org/a/605148)
 
+## Troubleshooting API Token Storage
+
+If you experience issues with the keyring (e.g., `secret-tool` errors), HTB Toolkit supports a fallback configuration file:
+
+1. Create the config directory:
+````bash
+   mkdir -p ~/.config/htb-toolkit
+````
+
+2. Store your App Token in the config file:
+````bash
+   echo "YOUR_APP_TOKEN_HERE" > ~/.config/htb-toolkit/token
+   chmod 600 ~/.config/htb-toolkit/token
+````
+
+The toolkit will automatically use this fallback if the keyring is unavailable.
+
+**Note**: The keyring method is preferred for security. Only use the config file as a fallback.
+
 # Install
 
 ## Arch-based Linux distro
@@ -41,13 +60,16 @@ Install the following runtime dependencies:
 coreutils gnome-keyring gzip libsecret noto-fonts-emoji openssl openvpn ttf-nerd-fonts-symbols
 ```
 **Debian-based distros**
-```
+````
 coreutils fonts-noto-color-emoji gnome-keyring gzip libsecret-tools libssl-dev openvpn
+
+# Important: Ensure gnome-keyring daemon is running
+eval $(gnome-keyring-daemon --start --components=secrets 2>/dev/null)
 
 wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/NerdFontsSymbolsOnly.zip
 unzip NerdFontsSymbolsOnly.zip -x LICENSE readme.md -d ~/.fonts
 fc-cache -fv
-```
+````
 Install the following build dependencies:
 ```
 git cargo

--- a/src/list.rs
+++ b/src/list.rs
@@ -166,7 +166,17 @@ pub async fn list_machines(machine_type: &str) -> Vec<Machine> {
                 }
                 println!("\n");
             } else {
-                for entry in json_data["data"].as_array().unwrap().iter() {
+                // For "free" machines, json_data is the direct API response with "data" field
+                let data_array = match json_data.get("data").and_then(|d| d.as_array()) {
+                    Some(arr) => arr,
+                    None => {
+                        eprintln!("\x1B[31mERROR: Failed to parse 'data' field for free machines\x1B[0m");
+                        eprintln!("Response structure: {}", serde_json::to_string_pretty(&json_data).unwrap_or_default());
+                        return machine_list;
+                    }
+                };
+                
+                for entry in data_array.iter() {
 
                     let id = entry["id"].as_u64().unwrap_or(0);
                     let name = entry["name"].as_str().unwrap_or("Name not available").to_string();


### PR DESCRIPTION
## Summary

This PR fixes critical issues preventing htb-toolkit from functioning with the HTB API.

## Problems Fixed

### 1. 🔄 HTTP 302 Redirects Not Followed
The HTB API endpoints return HTTP 302 redirects, but `reqwest::blocking::Client` wasn't configured to follow them.

**Error**: `expected value at line 1 column `

### 2. 🔑 API Key Not Retrieved Outside Docker  
The `get_appkey()` function only worked inside Docker containers.

**Error**: `HTTP 401: Unauthenticated`

### 3. 📄 Poor Error Messages
JSON parsing errors didn't help with debugging.

## Changes Made

### `src/api.rs` (+20 -3)
- ✅ Added redirect policy to follow up to 10 redirects
- ✅ Added explicit `Accept` and `User-Agent` headers
- ✅ Added HTTP 401 detection with helpful error message
- ✅ Fixed Authorization header formatting

### `src/appkey.rs` (+83 -33)
- ✅ Fixed API key retrieval fallback chain
- ✅ Added config file fallback at `~/.config/htb-toolkit/token`
- ✅ Improved `get_appkey_from_keyring()` to trim output properly

### `src/list.rs` (+12 -1)
- ✅ Better error handling for JSON parsing
- ✅ Shows response structure on errors
- ✅ Prevents panics on `None` values

### `README.md` (+26 -2)
- ✅ Added troubleshooting section
- ✅ Documented config file fallback
- ✅ Updated Debian dependencies

## Testing

```bash
./htb-toolkit -l free
# ✅ Successfully lists all 15 free machines

./htb-toolkit -l retired
# ✅ Successfully lists all 489 retired machines
```

**Tested on**: Kali Linux with both keyring and config file methods

## Backward Compatibility
- ✅ All existing functionality preserved
- ✅ No breaking changes

## Stats
- **4 files changed**: 102 insertions(+), 39 deletions(-)